### PR TITLE
Improve dates parsing

### DIFF
--- a/src/main/scala/AfScr.scala
+++ b/src/main/scala/AfScr.scala
@@ -1,4 +1,5 @@
 import java.nio.file.Paths
+import java.time.ZoneId
 
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Keep, Sink, Source}
@@ -23,6 +24,14 @@ object AfScr extends Logging {
 
     val config = new TomlBasedAppConfig(Toml.parse(Paths.get(args(0))))
 
+    val maybeTimezone = config.timezoneId()
+    if (maybeTimezone.isEmpty) {
+      logger.error("No deals timezone configured")
+      System.exit(2)
+    }
+
+    val timezone = maybeTimezone.get
+
     val maybeDbUri = config.mongoDbUri()
     if (maybeDbUri.isEmpty) {
       logger.error("No DB URI configured")
@@ -40,7 +49,7 @@ object AfScr extends Logging {
     val networks: Map[String, NetworkDef] = config.networks()
     val count = dao.initialize() // make sure indices are created
       .flatMap(_ => // load stores and deals for every network
-        Future.sequence(networks.map { case (key, networkDef) => loadNetwork(key, networkDef) })
+        Future.sequence(networks.map { case (key, networkDef) => loadNetwork(key, networkDef, timezone) })
       )
 
     count.onComplete {
@@ -52,7 +61,11 @@ object AfScr extends Logging {
     }(system.dispatcher)
   }
 
-  def loadNetwork(networkKey: String, networkDef: NetworkDef)(implicit requestHandler: RequestHandler, dao: Dao, system: ActorSystem): Future[Long] = {
+  def loadNetwork(networkKey: String, networkDef: NetworkDef, tz: ZoneId)(
+    implicit requestHandler: RequestHandler,
+    dao: Dao,
+    system: ActorSystem
+  ): Future[Long] = {
 
     val stores = new StoresProvider(networkDef, requestHandler, Store(networkKey))
       .stream()
@@ -68,7 +81,7 @@ object AfScr extends Logging {
         case Success(value) => logger.info(s"Successfully save stores: $value")
           Source.future(stores)
             .mapConcat(identity)
-            .map(store => new DealsProvider(store, networkDef, requestHandler, delayer, Deal(store)))
+            .map(store => new DealsProvider(store, networkDef, requestHandler, delayer, Deal(store, tz)))
             .flatMapMerge(3, _.stream())
             .alsoToMat(Sink.fold(0L)((count, _) => count + 1))(Keep.right)
             .toMat(dao.dealsSink())(Keep.left)

--- a/src/main/scala/persistence/Deal.scala
+++ b/src/main/scala/persistence/Deal.scala
@@ -1,12 +1,10 @@
 package persistence
 
 import java.time._
-import java.time.format.DateTimeFormatter
 
 import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
 import org.slf4j.LoggerFactory
-
-import scala.util.{Failure, Success, Try}
+import util.DealDateUtil
 
 case class Deal(store: Store,
                 title: String,
@@ -18,11 +16,10 @@ case class Deal(store: Store,
                 dateEnd: ZonedDateTime)
 
 object Deal {
-  private lazy val DATE_FORMAT = DateTimeFormatter.ofPattern("dd/MM-yyyy")
 
   private lazy val LOGGER = LoggerFactory.getLogger("DealsParser")
 
-  def apply(store: Store, homeTimeZone: ZoneId)(node: ObjectNode): Deal = {
+  def apply(store: Store, dateTimeParser: DealDateUtil)(node: ObjectNode): Deal = {
     LOGGER.debug(s"Parsing persistence.Deal from $node for store ${store.internalId}")
 
     val name: String = Seq(
@@ -46,10 +43,9 @@ object Deal {
 
     val promoObj = node.withArray[ArrayNode]("potentialPromotions").get(0)
 
-    val (dealBeginsAt, dealEndsAt) = parseTimeBoundaries(
+    val (dealBeginsAt, dealEndsAt) = dateTimeParser.parseTimeBoundaries(
       Option(promoObj.get("startDate")).map(_.asText()),
       Option(promoObj.get("endDate")).map(_.asText()),
-      homeTimeZone
     )
 
     new Deal(
@@ -63,30 +59,4 @@ object Deal {
       dateEnd = dealEndsAt,
     )
   }
-
-  // TODO test it
-  private def parseTimeBoundaries(maybeDateBegin: Option[String], maybeDateEnd: Option[String], tz: ZoneId): (ZonedDateTime, ZonedDateTime) = {
-    val timeBegins: ZonedDateTime = parseDate(maybeDateBegin, tz, isDealsEnd = false)
-      .getOrElse(ZonedDateTime.now(tz))
-
-    val timeEnds = parseDate(maybeDateEnd, tz, isDealsEnd = true)
-      .getOrElse {
-        val dayOfWeek = timeBegins.getDayOfWeek
-        timeBegins.plusDays(DayOfWeek.values().length - dayOfWeek.getValue)
-      }
-
-    timeBegins -> timeEnds
-  }
-
-  private def parseDate(text: Option[String], tz: ZoneId, isDealsEnd: Boolean): Option[ZonedDateTime] = text.flatMap(value =>
-    Try(LocalDate.parse(value, DATE_FORMAT)) match {
-      case Failure(exception) =>
-        LOGGER.error(s"Unable to parse date $text", exception)
-        None
-      case Success(value) =>
-        // Deals begins at 00:00:00 of the specified date and ends at 23:59:59
-        val time = if (isDealsEnd) LocalTime.of(23, 59, 59, 0) else LocalTime.of(0, 0, 0, 0)
-        Some(value.atTime(time).atZone(tz))
-    }
-  )
 }

--- a/src/main/scala/util/DealDateUtil.scala
+++ b/src/main/scala/util/DealDateUtil.scala
@@ -1,0 +1,69 @@
+package util
+
+import java.time._
+import java.time.format.DateTimeFormatter
+
+import org.slf4j.LoggerFactory
+
+import scala.util.{Failure, Success, Try}
+
+trait DealDateUtil {
+  protected lazy val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM-yyyy")
+
+  /**
+   * Parses both begin and end time of a deal. It processes both of them at once as they might be dependent.
+   * The following rule applies:
+   * - The only supported date format is dd/MM-yyyy
+   * - None value is the same as incorrectly formatted value, implies missing value
+   * - Missing begin date is treated as `today` is the begin date
+   * - Missing end date is calculated based on the begin date. It will be on Sunday of the same week that start date belong
+   * - Deal's begin time will always be 00:00:00
+   * - Deal's end time will always be 23:59:59
+   *
+   * @param maybeDateBegin optional string representation of the begin date.
+   * @param maybeDateEnd   optional string representation of the end date
+   * @return pair of ZonedDateTime values first of which represent a Deal's begin time, the second - the Deal's end time
+   */
+  def parseTimeBoundaries(maybeDateBegin: Option[String], maybeDateEnd: Option[String]): (ZonedDateTime, ZonedDateTime)
+}
+
+/**
+ * Implementation of the DealDateParser
+ *
+ * @param tz      time zone all dead belong to
+ * @param dateNow provider for `today` value in the specified timezone
+ */
+class DealDateUtilImpl(private val tz: ZoneId, private val dateNow: ZoneId => LocalDate) extends DealDateUtil {
+
+  private val LOGGER = LoggerFactory.getLogger("DateTimeParser")
+
+  override def parseTimeBoundaries(maybeDateBegin: Option[String], maybeDateEnd: Option[String]): (ZonedDateTime, ZonedDateTime) = {
+    val dateBegins: LocalDate = parseDate(maybeDateBegin).getOrElse(dateNow(tz))
+
+    val timeEnds: LocalDate = parseDate(maybeDateEnd)
+      .getOrElse {
+        val dayOfWeek = dateBegins.getDayOfWeek
+        dateBegins.plusDays(DayOfWeek.values().length - dayOfWeek.getValue)
+      }
+
+    val dateTimeBegins = dateBegins
+      .atTime(LocalTime.of(0, 0, 0, 0))
+      .atZone(tz)
+
+    val dateTimeEnd = timeEnds
+      .atTime(LocalTime.of(23, 59, 59, 0))
+      .atZone(tz)
+
+    (dateTimeBegins, dateTimeEnd)
+  }
+
+  private def parseDate(text: Option[String]): Option[LocalDate] = text.flatMap(value =>
+    Try(LocalDate.parse(value, DATE_FORMAT)) match {
+      case Failure(exception) =>
+        LOGGER.error(s"Unable to parse date $text", exception)
+        None
+      case Success(value) => Some(value)
+    }
+  )
+
+}

--- a/src/test/scala/config/TomlBasedAppConfigTest.scala
+++ b/src/test/scala/config/TomlBasedAppConfigTest.scala
@@ -1,5 +1,7 @@
 package config
 
+import java.time.ZoneId
+
 import org.scalatest.wordspec.AnyWordSpec
 import org.tomlj.{Toml, TomlInvalidTypeException}
 
@@ -29,6 +31,37 @@ class TomlBasedAppConfigTest extends AnyWordSpec {
         assertThrows[TomlInvalidTypeException] {
           configFrom(toml).mongoDbUri()
         }
+      }
+    }
+  }
+
+  "timezone" when {
+    "contains correct region" should {
+      "return parsed value" in {
+        val toml = """timezone = "Australia/Darwin" """
+
+        assertResult(Some(ZoneId.of("Australia/Darwin")))(configFrom(toml).timezoneId())
+      }
+    }
+
+    "contains correct TZ name" should {
+      "return parsed value" in {
+        val toml = """timezone = "GMT+1" """
+
+        assertResult(Some(ZoneId.of("GMT+1")))(configFrom(toml).timezoneId())
+      }
+    }
+
+    "missing" should {
+      "return None" in {
+        assertResult(None)(configFrom("").mongoDbUri())
+      }
+    }
+
+    "incorrect" should {
+      "return None" in {
+        val toml = """timezone = "unknown" """
+        assertResult(None)(configFrom(toml).mongoDbUri())
       }
     }
   }

--- a/src/test/scala/providers/DealsProviderTest.scala
+++ b/src/test/scala/providers/DealsProviderTest.scala
@@ -1,5 +1,7 @@
 package providers
 
+import java.time.{ZoneId, ZonedDateTime}
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpEntity.Strict
 import akka.http.scaladsl.model._
@@ -20,6 +22,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.jdk.CollectionConverters._
 
+//noinspection TypeAnnotation,ZeroIndexToHead
 class DealsProviderTest extends AnyWordSpec with BeforeAndAfter {
 
   val store = new Store(
@@ -36,6 +39,9 @@ class DealsProviderTest extends AnyWordSpec with BeforeAndAfter {
     dealsLink = "http://pennys.one/deals?some=thing"
   )
 
+  val dealBegins = ZonedDateTime.of(2020, 1, 2, 0, 0, 0, 0, ZoneId.of("Australia/Darwin"))
+  val dealEnds = ZonedDateTime.of(2020, 2, 2, 0, 0, 0, 0, ZoneId.of("Australia/Darwin"))
+
   val theDeal = new Deal(
     store = store,
     title = "Fake deal",
@@ -43,8 +49,8 @@ class DealsProviderTest extends AnyWordSpec with BeforeAndAfter {
     priceUnit = None,
     priceOriginal = None,
     priceDisc = None,
-    dateStart = None,
-    dateEnd = None,
+    dateStart = dealBegins,
+    dateEnd = dealEnds,
   )
 
   val makeADeal: ObjectNode => Deal = (_: ObjectNode) => theDeal

--- a/src/test/scala/util/DealDateUtilImplTest.scala
+++ b/src/test/scala/util/DealDateUtilImplTest.scala
@@ -1,0 +1,65 @@
+package util
+
+import java.time.{LocalDate, ZoneId, ZonedDateTime}
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class DealDateUtilImplTest extends AnyWordSpec {
+
+  private val timezone = ZoneId.of("Australia/Darwin")
+  private val today = LocalDate.of(2020, 11, 11) // Tuesday, week 46, year 2020
+  private val sunday = LocalDate.of(2020, 11, 15) // Sunday, week 46, year 2020
+  private val dateNowProvider = { _: ZoneId => today }
+  private val parser = new DealDateUtilImpl(timezone, dateNowProvider)
+
+  "parseTimeBoundaries" when {
+    "no raw dates passed" should {
+      "return today's morning and sunday's evening" in {
+        assertResult((beginDateTime(today), endDateTime(sunday)))(parser.parseTimeBoundaries(None, None))
+      }
+    }
+
+    "wrongly formatted dates passed" should {
+      "act the same as no dates passed" in {
+        assertResult((beginDateTime(today), endDateTime(sunday)))(parser.parseTimeBoundaries(Some("2020-11-01"), Some("2020-11-02")))
+      }
+    }
+
+    "only start date passed" should {
+      "return start date's morning and sunday's evening" in {
+        val expectedDateBegin = LocalDate.of(2020, 12, 5)
+        val expectedDateEnd = LocalDate.of(2020, 12, 6)
+        assertResult((beginDateTime(expectedDateBegin), endDateTime(expectedDateEnd)))(parser.parseTimeBoundaries(Some("05/12-2020"), None))
+      }
+    }
+
+    "only start date passed and it is sunday" should {
+      "return sunday's morning and sunday's evening" in {
+        val expectedDateBegin = LocalDate.of(2020, 12, 6)
+        val expectedDateEnd = LocalDate.of(2020, 12, 6)
+        assertResult((beginDateTime(expectedDateBegin), endDateTime(expectedDateEnd)))(parser.parseTimeBoundaries(Some("06/12-2020"), None))
+      }
+    }
+
+    "only end date passed" should {
+      "return today's morning and passed date" in {
+        val expectedDateEnd = LocalDate.of(2020, 12, 5)
+        assertResult((beginDateTime(today), endDateTime(expectedDateEnd)))(parser.parseTimeBoundaries(None, Some("05/12-2020")))
+      }
+    }
+
+    "both dates passed" should {
+      "return both parsed" in {
+        val expectedDateBegin = LocalDate.of(2020, 12, 4)
+        val expectedDateEnd = LocalDate.of(2020, 12, 5)
+        assertResult((beginDateTime(expectedDateBegin), endDateTime(expectedDateEnd)))(parser.parseTimeBoundaries(Some("04/12-2020"), Some("05/12-2020")))
+      }
+    }
+
+  }
+
+  def beginDateTime(date: LocalDate): ZonedDateTime = date.atTime(0, 0, 0).atZone(timezone)
+
+  def endDateTime(date: LocalDate): ZonedDateTime = date.atTime(23, 59, 59).atZone(timezone)
+
+}


### PR DESCRIPTION
Creates a `timezone` config field that reflects timezone of a Deal's startDate and endDate.
It also changes the way those fields are parsed:
- If start date is missing, today (parsing date) is used 
- If end date is missing it is calculated to be at the end of the same week as start date (on Sunday)
- Start date's time will be 00:00:00
- End date's time will be 23:59:59